### PR TITLE
fixed Django 1.6 compatibility

### DIFF
--- a/loginurl/urls.py
+++ b/loginurl/urls.py
@@ -1,4 +1,4 @@
-from django.conf.urls.defaults import patterns, url
+from django.conf.urls import patterns, url
 from django.views.generic import RedirectView
 from django.conf import settings
 


### PR DESCRIPTION
django.conf.urls.defaults was removed in Django 1.6, use django.conf.urls instead.
https://docs.djangoproject.com/en/1.6/internals/deprecation/#id1
